### PR TITLE
replace deprecated hardware_interface API

### DIFF
--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -57,6 +57,9 @@ target_link_libraries(${PROJECT_NAME} franka_example_controllers_parameters Fran
 if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.20")
     target_compile_definitions(${PROJECT_NAME} PRIVATE HW_HAS_SET_NODISCARD)
 endif()
+if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.27")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HW_HAS_GET_OPT)
+endif()
 
 pluginlib_export_plugin_description_file(
         controller_interface franka_example_controllers.xml)
@@ -113,8 +116,8 @@ if(BUILD_TESTING)
         ${PROJECT_NAME}_gravity_test
         PUBLIC controller_interface_VERSION_MAJOR=${controller_interface_VERSION_MAJOR}
     )
-    if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.20")
-        target_compile_definitions(${PROJECT_NAME}_gravity_test PRIVATE HW_HAS_GET_BY_REF)
+    if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.27")
+        target_compile_definitions(${PROJECT_NAME}_gravity_test PRIVATE HW_HAS_GET_OPT)
     endif()
 
     ament_add_gmock(${PROJECT_NAME}_move_to_start_test test/test_move_to_start_example_controller.cpp)
@@ -125,8 +128,8 @@ if(BUILD_TESTING)
         ${PROJECT_NAME}_move_to_start_test
         PUBLIC controller_interface_VERSION_MAJOR=${controller_interface_VERSION_MAJOR}
     )
-    if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.20")
-        target_compile_definitions(${PROJECT_NAME}_move_to_start_test PRIVATE HW_HAS_GET_BY_REF)
+    if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.27")
+        target_compile_definitions(${PROJECT_NAME}_move_to_start_test PRIVATE HW_HAS_GET_OPT)
     endif()
 
     if(CHECK_TIDY)

--- a/franka_example_controllers/src/joint_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/joint_impedance_example_controller.cpp
@@ -129,8 +129,13 @@ void JointImpedanceExampleController::updateJointStates() {
     assert(position_interface.get_interface_name() == "position");
     assert(velocity_interface.get_interface_name() == "velocity");
 
+#ifdef HW_HAS_GET_OPT
+    q_(i) = position_interface.get_optional().value();
+    dq_(i) = velocity_interface.get_optional().value();
+#else
     q_(i) = position_interface.get_value();
     dq_(i) = velocity_interface.get_value();
+#endif
   }
 }
 

--- a/franka_example_controllers/src/move_to_start_example_controller.cpp
+++ b/franka_example_controllers/src/move_to_start_example_controller.cpp
@@ -141,8 +141,13 @@ void MoveToStartExampleController::updateJointStates() {
     assert(position_interface.get_interface_name() == "position");
     assert(velocity_interface.get_interface_name() == "velocity");
 
+#ifdef HW_HAS_GET_OPT
+    q_(i) = position_interface.get_optional().value();
+    dq_(i) = velocity_interface.get_optional().value();
+#else
     q_(i) = position_interface.get_value();
     dq_(i) = velocity_interface.get_value();
+#endif
   }
 }
 }  // namespace franka_example_controllers

--- a/franka_example_controllers/test/test_gravity_compensation_example.cpp
+++ b/franka_example_controllers/test/test_gravity_compensation_example.cpp
@@ -30,9 +30,8 @@ using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::LoanedCommandInterface;
 
 void assert_val_eq(const CommandInterface& cmdintf) {
-#ifdef HW_HAS_GET_BY_REF
-  double val = 0;
-  EXPECT_TRUE(cmdintf.get_value(val));
+#ifdef HW_HAS_GET_OPT
+  const double val = cmdintf.get_optional().value();
 #else
   const double val = cmdintf.get_value();
 #endif

--- a/franka_example_controllers/test/test_move_to_start_example_controller.cpp
+++ b/franka_example_controllers/test/test_move_to_start_example_controller.cpp
@@ -27,9 +27,8 @@
 const double k_EPS = 1e-5;
 
 void exp_val_near(const CommandInterface& cmdintf) {
-#ifdef HW_HAS_GET_BY_REF
-  double val = 0;
-  EXPECT_TRUE(cmdintf.get_value(val));
+#ifdef HW_HAS_GET_OPT
+  const double val = cmdintf.get_optional().value();
 #else
   const double val = cmdintf.get_value();
 #endif

--- a/franka_hardware/test/CMakeLists.txt
+++ b/franka_hardware/test/CMakeLists.txt
@@ -4,6 +4,6 @@ ament_add_gmock(${PROJECT_NAME}_test franka_hardware_interface_test.cpp)
 target_include_directories(${PROJECT_NAME}_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(${PROJECT_NAME}_test  ${PROJECT_NAME})
 
-if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.20")
-    target_compile_definitions(${PROJECT_NAME}_test PRIVATE HW_HAS_GET_BY_REF)
+if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.27")
+    target_compile_definitions(${PROJECT_NAME}_test PRIVATE HW_HAS_GET_OPT)
 endif()

--- a/franka_hardware/test/franka_hardware_interface_test.cpp
+++ b/franka_hardware/test/franka_hardware_interface_test.cpp
@@ -137,9 +137,8 @@ TEST(
     } else {
       EXPECT_EQ(states[i].get_name(), joint_name + "/" + k_effort_controller);
     }
-#ifdef HW_HAS_GET_BY_REF
-    double val = 0;
-    EXPECT_TRUE(states[i].get_value(val));
+#ifdef HW_HAS_GET_OPT
+    const double val = states[i].get_optional().value();
 #else
     const double val = states[i].get_value();
 #endif
@@ -173,9 +172,8 @@ TEST(
   auto states = franka_hardware_interface.export_state_interfaces();
   EXPECT_EQ(states[state_interface_size - 1].get_name(),
             "panda/robot_model");  // Last state interface is the robot model state
-#ifdef HW_HAS_GET_BY_REF
-  double val = 0;
-  EXPECT_TRUE(states[state_interface_size - 1].get_value(val));
+#ifdef HW_HAS_GET_OPT
+  const double val = states[state_interface_size - 1].get_optional().value();
 #else
   const double val = states[state_interface_size - 1].get_value();
 #endif
@@ -210,9 +208,8 @@ TEST(
   auto states = franka_hardware_interface.export_state_interfaces();
   EXPECT_EQ(states[state_interface_size - 2].get_name(),
             "panda/robot_state");  // Last state interface is the robot model state
-#ifdef HW_HAS_GET_BY_REF
-  double val = 0;
-  EXPECT_TRUE(states[state_interface_size - 2].get_value(val));
+#ifdef HW_HAS_GET_OPT
+  const double val = states[state_interface_size - 2].get_optional().value();
 #else
   const double val = states[state_interface_size - 2].get_value();
 #endif

--- a/franka_hardware/test/franka_hardware_interface_test.cpp
+++ b/franka_hardware/test/franka_hardware_interface_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <exception>
 #include <rclcpp/rclcpp.hpp>
 
 #include <franka_hardware/franka_hardware_interface.hpp>


### PR DESCRIPTION
The function `get_value()` to read values from a hardware interface is deprecated and will be removed in future ROS 2 versions. Replace it by the new `get_optional()` function.