### PR TITLE
fix set_value template argument deduction

### DIFF
--- a/franka_example_controllers/src/gravity_compensation_example_controller.cpp
+++ b/franka_example_controllers/src/gravity_compensation_example_controller.cpp
@@ -40,7 +40,7 @@ controller_interface::return_type GravityCompensationExampleController::update(
     const rclcpp::Duration& /*period*/) {
   for (auto& command_interface : command_interfaces_) {
 #ifdef HW_HAS_SET_NODISCARD
-    if (!command_interface.set_value(0))
+    if (!command_interface.set_value<double>(0))
       return controller_interface::return_type::ERROR;
 #else
     command_interface.set_value(0);

--- a/franka_example_controllers/src/move_to_start_example_controller.cpp
+++ b/franka_example_controllers/src/move_to_start_example_controller.cpp
@@ -69,7 +69,7 @@ controller_interface::return_type MoveToStartExampleController::update(
   } else {
     for (auto& command_interface : command_interfaces_) {
 #ifdef HW_HAS_SET_NODISCARD
-      if (!command_interface.set_value(0))
+      if (!command_interface.set_value<double>(0))
         return controller_interface::return_type::ERROR;
 #else
       command_interface.set_value(0);


### PR DESCRIPTION
A recent change in the `hardware_interface` API (4.28) leads to a compilation error due to a template argument deduction from `0` to `int`. Avoid this by explicitly specifying template argument `double`.