### PR TITLE
return OK if FrankaRobotStateBroadcaster cannot lock publisher

### DIFF
--- a/franka_robot_state_broadcaster/CMakeLists.txt
+++ b/franka_robot_state_broadcaster/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Werror=return-type)
 endif()
 
 option(CHECK_TIDY "Adds clang-tidy tests" OFF)

--- a/franka_robot_state_broadcaster/src/franka_robot_state_broadcaster.cpp
+++ b/franka_robot_state_broadcaster/src/franka_robot_state_broadcaster.cpp
@@ -108,11 +108,9 @@ controller_interface::return_type FrankaRobotStateBroadcaster::update(
       return controller_interface::return_type::ERROR;
     }
     realtime_franka_state_publisher->unlockAndPublish();
-    return controller_interface::return_type::OK;
-
-  } else {
-    return controller_interface::return_type::ERROR;
   }
+
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace franka_robot_state_broadcaster


### PR DESCRIPTION
`FrankaRobotStateBroadcaster::update` returns `ERROR` when it cannot lock the `RealtimePublisher` via `trylock()`. This is too conservative, considering the reference implementations [`JointStateBroadcaster::update`](https://github.com/ros-controls/ros2_controllers/blob/4.24.0/joint_state_broadcaster/src/joint_state_broadcaster.cpp#L403-L447), [`PoseBroadcaster::update`](https://github.com/ros-controls/ros2_controllers/blob/4.24.0/pose_broadcaster/src/pose_broadcaster.cpp#L164-L223), and [`IMUSensorBroadcaster::update`](https://github.com/ros-controls/ros2_controllers/blob/4.24.0/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp#L113-L124), which all return `OK` if `trylock()` fails.

Align the behaviour of `FrankaRobotStateBroadcaster` by also return `OK` in this case. This fixes on startup, where previously the activation would fail.