### PR TITLE
update on_init API

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        distribution: ["humble", "jazzy"]
+        distribution: ["jazzy"]
 
     container:
       image: ros:${{ matrix.distribution }}-ros-core

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -10,7 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        distribution: ["jazzy"]
+        include:
+        - {distribution: "jazzy", WARNING_AS_ERROR: "ON"}
 
     container:
       image: ros:${{ matrix.distribution }}-ros-core
@@ -33,4 +34,4 @@ jobs:
       with:
         target-ros2-distro: ${{ matrix.distribution }}
         vcs-repo-file-url: ${{ github.workspace }}/.github/workflows/libfranka.repos
-        extra-cmake-args: "-D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=OFF -D BUILD_TESTING=ON -D BUILD_EXAMPLES=OFF"
+        extra-cmake-args: "-D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=OFF -D BUILD_TESTING=ON -D BUILD_EXAMPLES=OFF -D CMAKE_COMPILE_WARNING_AS_ERROR=${{ matrix.WARNING_AS_ERROR }}"

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -29,7 +29,7 @@ jobs:
         sparse-checkout: .github/workflows/libfranka.repos
         sparse-checkout-cone-mode: false
 
-    - uses: ros-tooling/action-ros-ci@v0.3
+    - uses: ros-tooling/action-ros-ci@v0.4
       with:
         target-ros2-distro: ${{ matrix.distribution }}
         vcs-repo-file-url: ${{ github.workspace }}/.github/workflows/libfranka.repos

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -24,7 +24,7 @@ jobs:
         apt install -y --no-install-recommends git build-essential
         rosdep init
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: .github/workflows/libfranka.repos
         sparse-checkout-cone-mode: false

--- a/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
+++ b/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
@@ -51,7 +51,8 @@ class FrankaHardwareInterface : public hardware_interface::SystemInterface {
                                        const rclcpp::Duration& period) override;
   hardware_interface::return_type write(const rclcpp::Time& time,
                                         const rclcpp::Duration& period) override;
-  CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+  CallbackReturn on_init(
+      const hardware_interface::HardwareComponentInterfaceParams& params) override;
   static const size_t kNumberOfJoints = 7;
 
  private:

--- a/franka_hardware/src/franka_hardware_interface.cpp
+++ b/franka_hardware/src/franka_hardware_interface.cpp
@@ -108,8 +108,9 @@ hardware_interface::return_type FrankaHardwareInterface::write(const rclcpp::Tim
   return hardware_interface::return_type::OK;
 }
 
-CallbackReturn FrankaHardwareInterface::on_init(const hardware_interface::HardwareInfo& info) {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+CallbackReturn FrankaHardwareInterface::on_init(
+    const hardware_interface::HardwareComponentInterfaceParams& params) {
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
   if (info_.joints.size() != kNumberOfJoints) {

--- a/franka_hardware/test/CMakeLists.txt
+++ b/franka_hardware/test/CMakeLists.txt
@@ -4,6 +4,10 @@ ament_add_gmock(${PROJECT_NAME}_test franka_hardware_interface_test.cpp)
 target_include_directories(${PROJECT_NAME}_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(${PROJECT_NAME}_test  ${PROJECT_NAME})
 
+# ignore "dereferencing type-punned pointer will break strict-aliasing rules" for
+# "*reinterpret_cast<double*>(&model_address)"
+target_compile_options(${PROJECT_NAME}_test PRIVATE "-Wno-error=strict-aliasing")
+
 if(${hardware_interface_VERSION} VERSION_GREATER_EQUAL "4.27")
     target_compile_definitions(${PROJECT_NAME}_test PRIVATE HW_HAS_GET_OPT)
 endif()

--- a/franka_hardware/test/franka_hardware_interface_test.cpp
+++ b/franka_hardware/test/franka_hardware_interface_test.cpp
@@ -41,12 +41,12 @@ class MockRobot : public franka_hardware::Robot {
   MOCK_METHOD(MockModel*, getModel, (), (override));
 };
 
-auto createHardwareInfo() -> hardware_interface::HardwareInfo {
-  hardware_interface::HardwareInfo info;
+auto createHardwareInfo() -> hardware_interface::HardwareComponentInterfaceParams {
+  hardware_interface::HardwareComponentInterfaceParams params;
   std::unordered_map<std::string, std::string> hw_params;
   hw_params["robot_ip"] = "dummy_ip";
 
-  info.hardware_parameters = hw_params;
+  params.hardware_info.hardware_parameters = hw_params;
   hardware_interface::InterfaceInfo command_interface, effort_state_interface,
       position_state_interface, velocity_state_interface;
 
@@ -67,17 +67,17 @@ auto createHardwareInfo() -> hardware_interface::HardwareInfo {
     joint.command_interfaces.push_back(command_interface);
     joint.state_interfaces = state_interfaces;
 
-    info.joints.push_back(joint);
+    params.hardware_info.joints.push_back(joint);
   }
 
-  return info;
+  return params;
 }
 
 TEST(FrankaHardwareInterfaceTest, when_on_init_called_expect_success) {
   auto mock_robot = std::make_unique<MockRobot>();
-  const hardware_interface::HardwareInfo info = createHardwareInfo();
+  const auto params = createHardwareInfo();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
-  auto return_type = franka_hardware_interface.on_init(info);
+  auto return_type = franka_hardware_interface.on_init(params);
 
   EXPECT_EQ(return_type,
             rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
@@ -114,8 +114,8 @@ TEST(
   EXPECT_CALL(*mock_robot, read()).WillOnce(testing::Return(robot_state));
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   auto time = rclcpp::Time(0);
   auto duration = rclcpp::Duration(0, 0);
   auto return_type = franka_hardware_interface.read(time, duration);
@@ -162,8 +162,8 @@ TEST(
   EXPECT_CALL(*mock_robot, getModel()).WillOnce(testing::Return(model_address));
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   auto time = rclcpp::Time(0);
   auto duration = rclcpp::Duration(0, 0);
   auto return_type = franka_hardware_interface.read(time, duration);
@@ -198,8 +198,8 @@ TEST(
   EXPECT_CALL(*mock_robot, getModel()).WillOnce(testing::Return(model_address));
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   auto time = rclcpp::Time(0);
   auto duration = rclcpp::Duration(0, 0);
   auto return_type = franka_hardware_interface.read(time, duration);
@@ -222,11 +222,11 @@ TEST(FrankaHardwareInterfaceTest,
   auto mock_robot = std::make_unique<MockRobot>();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> stop_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     stop_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -241,11 +241,11 @@ TEST(
   auto mock_robot = std::make_unique<MockRobot>();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> stop_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     stop_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -260,11 +260,11 @@ TEST(FrankaHardwareInterfaceTest,
   auto mock_robot = std::make_unique<MockRobot>();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> start_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     start_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -281,11 +281,11 @@ TEST(
   auto mock_robot = std::make_unique<MockRobot>();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> start_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     start_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -301,8 +301,8 @@ TEST(FrankaHardwareIntefaceTest, when_write_called_expect_ok) {
   auto mock_robot = std::make_unique<MockRobot>();
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
 
   const auto time = rclcpp::Time(0, 0);
   const auto duration = rclcpp::Duration(0, 0);
@@ -348,11 +348,11 @@ TEST(FrankaHardwareInterfaceTest,
 
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> start_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     start_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -375,11 +375,11 @@ TEST(FrankaHardwareInterfaceTest,
 
   franka_hardware::FrankaHardwareInterface franka_hardware_interface(std::move(mock_robot));
 
-  const auto hardware_info = createHardwareInfo();
-  franka_hardware_interface.on_init(hardware_info);
+  const auto params = createHardwareInfo();
+  franka_hardware_interface.on_init(params);
   std::vector<std::string> start_interface;
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     start_interface.push_back(joint_name + "/" + k_effort_controller);
   }
@@ -392,7 +392,7 @@ TEST(FrankaHardwareInterfaceTest,
   EXPECT_EQ(franka_hardware_interface.perform_command_mode_switch(start_interface, stop_interface),
             hardware_interface::return_type::OK);
 
-  for (size_t i = 0; i < hardware_info.joints.size(); i++) {
+  for (size_t i = 0; i < params.hardware_info.joints.size(); i++) {
     const std::string joint_name = k_joint_name + std::to_string(i);
     stop_interface.push_back(joint_name + "/" + k_effort_controller);
   }

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -34,6 +34,7 @@ import yaml
 # backport 'IfElseSubstitution' from 'launch':
 # https://github.com/ros2/launch/blob/3.7.1/launch/launch/substitutions/if_else_substitution.py
 class CustomIfElseSubstitution(Substitution):
+
     def __init__(self, condition, if_value, else_value) -> None:
         from launch.utilities import normalize_to_list_of_substitutions
         super().__init__()

--- a/franka_robot_state_broadcaster/include/franka_robot_state_broadcaster/franka_robot_state_broadcaster.hpp
+++ b/franka_robot_state_broadcaster/include/franka_robot_state_broadcaster/franka_robot_state_broadcaster.hpp
@@ -56,6 +56,7 @@ class FrankaRobotStateBroadcaster : public controller_interface::ControllerInter
   std::shared_ptr<realtime_tools::RealtimePublisher<franka_msgs::msg::FrankaRobotState>>
       realtime_franka_state_publisher;
   std::unique_ptr<franka_semantic_components::FrankaRobotState> franka_robot_state;
+  franka_msgs::msg::FrankaRobotState msg_state;
 };
 
 }  // namespace franka_robot_state_broadcaster

--- a/franka_robot_state_broadcaster/src/franka_robot_state_broadcaster.cpp
+++ b/franka_robot_state_broadcaster/src/franka_robot_state_broadcaster.cpp
@@ -98,16 +98,22 @@ controller_interface::CallbackReturn FrankaRobotStateBroadcaster::on_deactivate(
 controller_interface::return_type FrankaRobotStateBroadcaster::update(
     const rclcpp::Time& time,
     const rclcpp::Duration& /*period*/) {
-  if (realtime_franka_state_publisher && realtime_franka_state_publisher->trylock()) {
-    realtime_franka_state_publisher->msg_.header.stamp = time;
-
-    if (!franka_robot_state->get_values_as_message(realtime_franka_state_publisher->msg_)) {
+  if (realtime_franka_state_publisher) {
+    // get state
+    if (!franka_robot_state->get_values_as_message(msg_state)) {
       RCLCPP_ERROR(get_node()->get_logger(),
                    "Failed to get franka state via franka state interface.");
-      realtime_franka_state_publisher->unlock();
       return controller_interface::return_type::ERROR;
     }
-    realtime_franka_state_publisher->unlockAndPublish();
+
+    // update time stamp
+    msg_state.header.stamp = time;
+
+    // publish state
+    if (!realtime_franka_state_publisher->try_publish(msg_state)) {
+      RCLCPP_ERROR(get_node()->get_logger(), "Cannot publish franka state.");
+      return controller_interface::return_type::ERROR;
+    }
   }
 
   return controller_interface::return_type::OK;


### PR DESCRIPTION
See https://control.ros.org/master/doc/ros2_control/doc/migration.html and https://github.com/ros-controls/ros2_control/pull/2323.

This drops `humble` support in order to simplify maintenance.

The `rolling` CI is missing the apt package `ros-rolling-moveit-ros-visualization` (`E: Unable to locate package ros-rolling-moveit-ros-visualization`). At the moment, it is only available on the "testing" repo.