### PR TITLE
allow executing trajectories with non-zero end velocity

### DIFF
--- a/franka_moveit_config/config/panda_ros_controllers.yaml
+++ b/franka_moveit_config/config/panda_ros_controllers.yaml
@@ -22,6 +22,7 @@ panda_arm_controller:
     state_interfaces:
       - position
       - velocity
+    allow_nonzero_velocity_at_trajectory_end: true
     joints:
       - panda_joint1
       - panda_joint2


### PR DESCRIPTION
Some module in MoveIt2, e.g. `moveit_servo`, provide joint trajectories with a non-zero velocity at the end: https://github.com/moveit/moveit2/issues/3561.

This does not work with the "real" `panda_arm_controller`, as this is expecting a zero end velocity by default. Work around this by setting `allow_nonzero_velocity_at_trajectory_end` to `true` by default.